### PR TITLE
WIP: Conditional posting via favourites

### DIFF
--- a/migrations/versions/abcdef012345_conditional_posting_with_faves.py
+++ b/migrations/versions/abcdef012345_conditional_posting_with_faves.py
@@ -1,0 +1,29 @@
+"""empty message
+
+Revision ID: abcdef012345
+Revises: 52a6ff8551e1
+Create Date: 2019-03-10 20:44:12.345678
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'abcdef012345'
+down_revision = '52a6ff8551e1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    ## Rename existing conditional_posting column for clarity.
+    # op.alter_column('settings', 'conditional_posting', new_column_name='conditional_posting_hashtags')
+    op.add_column('settings', sa.Column('conditional_posting_faves', sa.Boolean(), nullable=False))
+
+
+def downgrade():
+    ## Should be dropped in dc37a95190f6, provided it's correctly renamed back.
+    # op.alter_column('settings', 'conditional_posting_hashtags', new_column_name='conditional_posting')
+    op.drop_column('settings', 'conditional_posting_faves')
+    

--- a/moa/forms.py
+++ b/moa/forms.py
@@ -6,6 +6,7 @@ from wtforms.validators import DataRequired, Email, Length
 class SettingsForm(FlaskForm):
     enabled = BooleanField('Bridging Enabled?')
     conditional_posting = BooleanField('Conditionally cross-post with hashtags #nt and #nm?')
+    conditional_posting_faves = BooleanField('Conditionally cross-post by marking your posts as faves?')
 
     post_to_twitter = BooleanField('Post Public toots to Twitter?')
     post_private_to_twitter = BooleanField('Post Private toots to Twitter?')

--- a/moa/models.py
+++ b/moa/models.py
@@ -32,6 +32,7 @@ class TSettings(Base):
     id = Column(Integer, primary_key=True)
     bridge = relationship('Bridge', backref='t_settings', lazy='dynamic')
     conditional_posting = Column(Boolean, nullable=False, default=False)
+    conditional_posting_faves = Column(Boolean, nullable=False, default=False)
 
     # Masto -> Twitter
     post_to_twitter = Column(Boolean, nullable=False, default=True)  # This means post public toots

--- a/moa/toot.py
+++ b/moa/toot.py
@@ -78,6 +78,10 @@ class Toot(Message):
         return self.is_reply and self.data['in_reply_to_account_id'] == self.data['account']['id']
 
     @property
+    def is_favourited(self):
+        return self.data['favourited']
+
+    @property
     def is_boost(self):
         return self.data['reblog'] is not None
 
@@ -146,6 +150,11 @@ class Toot(Message):
             # If it's a boost and boosts are allowed then post it even
             # if public toots aren't allowed
             pass
+
+        elif self.settings.conditional_posting_faves and not self.is_favourited:
+            logger.info(f'Skipping: Not posting unfavourited toot')
+            pass
+
         elif self.settings.conditional_posting:
 
             for ht in self.data['tags']:

--- a/moa/toot.py
+++ b/moa/toot.py
@@ -153,7 +153,7 @@ class Toot(Message):
 
         elif self.settings.conditional_posting_faves and not self.is_favourited:
             logger.info(f'Skipping: Not posting unfavourited toot')
-            pass
+            return True
 
         elif self.settings.conditional_posting:
 

--- a/moa/tweet.py
+++ b/moa/tweet.py
@@ -98,6 +98,10 @@ class Tweet(Message):
             # Posting retweets
             pass
 
+        elif self.settings.conditional_posting_faves and not self.is_favorited:
+            logger.info(f'Skipping: Not posting unfavorited tweet')
+            return True
+
         elif self.settings.conditional_posting:
 
             for ht in self.data.hashtags:
@@ -137,6 +141,10 @@ class Tweet(Message):
     @property
     def is_quoted(self):
         return self.data.quoted_status is not None
+
+    @property
+    def is_favorited(self):
+        return self.data.favorited
 
     @property
     def is_reply(self):

--- a/templates/index.html.j2
+++ b/templates/index.html.j2
@@ -37,6 +37,7 @@
             <hr>
             <li>{{ form.enabled(checked=g.bridge.enabled) }}{{ form.enabled.label }}</li>
             <li>{{ form.conditional_posting }}{{ form.conditional_posting.label }}</li>
+            <li>{{ form.conditional_posting_faves }}{{ form.conditional_posting_faves.label }}</li>
             {% endif %}
 
             {% if g.bridge.twitter_oauth_token and g.bridge.mastodon_access_code %}


### PR DESCRIPTION
Rather than requiring the user to include a hashtag to set conditional cross-posting (which I don't like because the user then has to mention other, less cool networks when posting, sullying their carefully crafted toots with unsightly metadata), this empowers moa.party users to opt into post relaying by tapping the :star: button, which is empowering and excellent UX.

See #108.

I'm testing this myself, it's WIP and I hope @foozmeat will give some input on improving my submission.

Todo:

- [ ] Correctly rename the migration changes.
- [ ] Rename existing conditional_posting column (to conditional_posting_hashtags?) for less confusion.
- [ ] Instagram support also (they have faves, right?)